### PR TITLE
Fix external link usage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,14 +58,14 @@ export default function Home() {
               
               {/* Work With Me Button */}
               <div className="mt-8 text-center lg:text-left">
-                <Link
+                <a
                   href="https://cal.com/ivanleo"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-block border border-gray-900 text-gray-900 px-6 py-2 font-[family-name:var(--font-lato)] text-sm tracking-wide hover:bg-gray-900 hover:text-white transition-all duration-200"
                 >
                   Work With Me
-                </Link>
+                </a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- use a normal anchor tag for the external "Work With Me" link

## Testing
- `npm run lint` *(fails: `next` not found)*