### PR TITLE
feat: remove cal.com link from front page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,17 +56,6 @@ export default function Home() {
                 </p>
               </div>
 
-              {/* Work With Me Button */}
-              <div className="mt-8 text-center lg:text-left">
-                <a
-                  href="https://cal.com/ivanleomk/30min"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-block border border-gray-900 text-gray-900 px-6 py-2 font-[family-name:var(--font-lato)] text-sm tracking-wide hover:bg-gray-900 hover:text-white transition-all duration-200"
-                >
-                  Work With Me
-                </a>
-              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Remove the 'Work With Me' button that linked to cal.com/ivanleomk/30min as requested in issue #21.

Generated with [Claude Code](https://claude.ai/code)

---

<span data-mesa-description="start"></span>
## TL;DR
Removed the 'Work With Me' button and its Cal.com scheduling link from the front page.

## Why we made these changes
To fulfill the request in issue #21 to remove the Cal.com scheduling link.

## What changed?
- `src/app/page.tsx`: The 'Work With Me' button and its associated `cal.com` link were removed from the Home component.

## Validation
- [ ] Verified the 'Work With Me' button is no longer present on the home page.
- [ ] Confirmed no layout regressions or broken elements on the front page.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/ivanleomk/settings/pull-requests)_</sup>
<span data-mesa-description="end"></span>